### PR TITLE
Add `caseInsensitive` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare namespace replaceString {
 	type ReplacementFunction = (
-		needle: string,
+		matchedSubstring: string,
 		matchCount: number,
 		input: string,
 		matchIndex: number
@@ -13,6 +13,13 @@ declare namespace replaceString {
 		@default 0
 		*/
 		readonly fromIndex?: number;
+
+		/**
+		Whether or not substring matching should be case-insensitive.
+
+		@default false
+		*/
+		readonly caseInsensitive?: boolean;
 	}
 }
 
@@ -33,7 +40,7 @@ const string = 'My friend has a 🐑. I want a 🐑 too!';
 replaceString(string, '🐑', '🦄');
 //=> 'My friend has a 🦄. I want a 🦄 too!'
 
-replaceString('Foo 🐑 Bar', '🐑', (needle, matchCount, input, matchIndex) => `${needle}❤️`);
+replaceString('Foo 🐑 Bar', '🐑', (matchedSubstring, matchCount, input, matchIndex) => `${matchedSubstring}❤️`);
 //=> 'Foo 🐑❤️ Bar'
 ```
 */

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports = (string, needle, replacement, options = {}) => {
 	}
 
 	while (true) { // eslint-disable-line no-constant-condition
-		const index = string.indexOf(needle, prevIndex);
+		const index = (options && options.caseInsensitive) ?
+			string.toLowerCase().indexOf(needle.toLowerCase(), prevIndex) :
+			string.indexOf(needle, prevIndex);
 
 		if (index === -1) {
 			break;
@@ -27,7 +29,13 @@ module.exports = (string, needle, replacement, options = {}) => {
 
 		matchCount++;
 
-		const replaceStr = typeof replacement === 'string' ? replacement : replacement(needle, matchCount, string, index);
+		const replaceStr = typeof replacement === 'string' ? replacement : replacement(
+			// If caseInsensitive is enabled, the matched substring may be different from the needle
+			string.slice(index, index + needle.length),
+			matchCount,
+			string,
+			index
+		);
 
 		// Get the initial part of the string on the first iteration
 		const beginSlice = matchCount === 1 ? 0 : prevIndex;

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = (string, needle, replacement, options = {}) => {
 	}
 
 	while (true) { // eslint-disable-line no-constant-condition
-		const index = (options && options.caseInsensitive) ?
+		const index = options.caseInsensitive ?
 			string.toLowerCase().indexOf(needle.toLowerCase(), prevIndex) :
 			string.indexOf(needle, prevIndex);
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,3 +16,5 @@ expectType<string>(
 	})
 );
 expectType<string>(replaceString(input, '🐑', '🦄', {fromIndex: 1}));
+expectType<string>(replaceString(input, '🐑', '🦄', {caseInsensitive: true as boolean}));
+expectType<string>(replaceString(input, '🐑', '🦄', {fromIndex: 1, caseInsensitive: true as boolean}));

--- a/readme.md
+++ b/readme.md
@@ -48,10 +48,10 @@ Type: `string | Function`
 
 Replacement for `needle` matches.
 
-If a function, it receives the following arguments; the `needle`, the match count, and the `input`:
+If a function, it receives the matched substring, the match count, the original input, and the index in which the match happened (as measured from the original input):
 
 ```js
-replaceString('Foo 🐑 Bar', '🐑', (needle, matchCount, input, matchIndex) => `${needle}❤️`);
+replaceString('Foo 🐑 Bar', '🐑', (matchedSubstring, matchCount, input, matchIndex) => `${matchedSubstring}❤️`);
 //=> 'Foo 🐑❤️ Bar'
 ```
 
@@ -65,6 +65,13 @@ Type: `number`<br>
 Default: `0`
 
 Index at which to start replacing.
+
+##### caseInsensitive
+
+Type: `boolean`<br>
+Default: `false`
+
+Whether or not substring matching should be case-insensitive.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -28,20 +28,22 @@ test('main', t => {
 	t.is(replaceString('foo', 'foo', 'bar', {fromIndex: -100}), 'bar');
 	t.is(replaceString('foo foo foo foo foo', 'foo', 'bar', {fromIndex: 1}), 'foo bar bar bar bar');
 	t.is(replaceString('bar foo', 'foo', 'bar', {fromIndex: 5}), 'bar foo');
+
+	t.is(replaceString('foo bar foo', 'Bar', 'Foo', {caseInsensitive: true}), 'foo Foo foo');
 });
 
 test('function replacement', t => {
-	const initNeedle = 'foo';
+	const needle = 'foo';
 	const countIndices = [];
 	const matchIndices = [];
 
 	t.is(
-		replaceString('foo bar baz foo baz', initNeedle, (needle, count, input, matchIndex) => {
-			t.is(needle, initNeedle);
+		replaceString('foo bar baz foo baz', needle, (matchedSubstring, count, input, matchIndex) => {
+			t.is(matchedSubstring, needle);
 			countIndices.push(count);
 			matchIndices.push(matchIndex);
 			t.is(typeof input, 'string');
-			return `${needle}2`;
+			return `${matchedSubstring}2`;
 		}),
 		'foo2 bar baz foo2 baz'
 	);
@@ -50,22 +52,42 @@ test('function replacement', t => {
 	t.deepEqual(matchIndices, [0, 12]);
 });
 
-test('function replacement with fromIndex', t => {
-	const initNeedle = 'foo';
+test('function replacement with `fromIndex` option', t => {
+	const needle = 'foo';
 	const countIndices = [];
 	const matchIndices = [];
 
 	t.is(
-		replaceString('foo bar baz foo baz', initNeedle, (needle, count, input, matchIndex) => {
-			t.is(needle, initNeedle);
+		replaceString('foo bar baz foo baz Foo', needle, (matchedSubstring, count, input, matchIndex) => {
+			t.is(matchedSubstring, needle);
 			countIndices.push(count);
 			matchIndices.push(matchIndex);
 			t.is(typeof input, 'string');
-			return `${needle}2`;
+			return `${matchedSubstring}2`;
 		}, {fromIndex: 5}),
-		'foo bar baz foo2 baz'
+		'foo bar baz foo2 baz Foo'
 	);
 
 	t.deepEqual(countIndices, [1]);
 	t.deepEqual(matchIndices, [12]);
+});
+
+test('function replacement with `fromIndex` and `caseInsensitive` options', t => {
+	const needle = 'fOO';
+	const countIndices = [];
+	const matchIndices = [];
+
+	t.is(
+		replaceString('fOO bar baz foo baz foo Foo fOo FoO', needle, (matchedSubstring, count, input, matchIndex) => {
+			t.is(matchedSubstring.toLowerCase(), needle.toLowerCase());
+			countIndices.push(count);
+			matchIndices.push(matchIndex);
+			t.is(typeof input, 'string');
+			return `${matchedSubstring}2`;
+		}, {fromIndex: 15, caseInsensitive: true}),
+		'fOO bar baz foo baz foo2 Foo2 fOo2 FoO2'
+	);
+
+	t.deepEqual(countIndices, [1, 2, 3, 4]);
+	t.deepEqual(matchIndices, [20, 24, 28, 32]); // Indexes are measured based on the original string
 });


### PR DESCRIPTION
This PR adds a `caseInsensitive` option, which defaults to `false` and therefore is not a breaking change.

Also, the `replacement` function now receives the matched substring as a first parameter, instead of the needle, which is not a breaking change for anyone not using the `caseInsensitive` option, and makes much more sense for anyone using `caseInsensitive: true`.